### PR TITLE
Fix link in the docs

### DIFF
--- a/deployment.md
+++ b/deployment.md
@@ -12,7 +12,7 @@ Before you deploy your DAO, you should ask yourself the following questions:
 - What kind of proposals do you expect?
 - Who are the first members? 
 
-[Deploy your own DAO](https://w3hc.github.io/gov-docs/deployment.html){: .btn .btn-purple }
+[Deploy your own DAO](https://gov-deployer.on.fleek.co/){: .btn .btn-purple }
 
 ## Checklist
 

--- a/deployment.md
+++ b/deployment.md
@@ -12,7 +12,7 @@ Before you deploy your DAO, you should ask yourself the following questions:
 - What kind of proposals do you expect?
 - Who are the first members? 
 
-[Deploy your own DAO](https://gov-ui.on.fleek.co/){: .btn .btn-purple }
+[Deploy your own DAO](https://w3hc.github.io/gov-docs/deployment.html){: .btn .btn-purple }
 
 ## Checklist
 

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Also, we have successfully tested [Medusa](https://medusanet.xyz/) (Arbitrum Goe
 
 You can find the deployment checklist [here](./deployment.html#checklist). Once you decided about (1) your mission statement, (2) the types of proposals you expect, and (3) the [vote settings](./vote-settings.html#guide), we can take an hour to deploy your DAO to the network of your choice. Feel very free to contact Julien directly via [Element](https://matrix.to/#/@julienbrg:matrix.org), [Telegram](https://t.me/julienbrg), [Twitter](https://twitter.com/julienbrg), [Discord](https://discord.com/invite/uSxzJp3J76), or [LinkedIn](https://www.linkedin.com/in/julienberanger/).
 
-[Deploy your own DAO](https://w3hc.github.io/gov-docs/deployment.html){: .btn .btn-purple }
+[Deploy your own DAO](https://gov-deployer.on.fleek.co/){: .btn .btn-purple }
 
 ## Features
 

--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Also, we have successfully tested [Medusa](https://medusanet.xyz/) (Arbitrum Goe
 
 You can find the deployment checklist [here](./deployment.html#checklist). Once you decided about (1) your mission statement, (2) the types of proposals you expect, and (3) the [vote settings](./vote-settings.html#guide), we can take an hour to deploy your DAO to the network of your choice. Feel very free to contact Julien directly via [Element](https://matrix.to/#/@julienbrg:matrix.org), [Telegram](https://t.me/julienbrg), [Twitter](https://twitter.com/julienbrg), [Discord](https://discord.com/invite/uSxzJp3J76), or [LinkedIn](https://www.linkedin.com/in/julienberanger/).
 
-[Deploy your own DAO](https://gov-deployer.on.fleek.co/){: .btn .btn-purple }
+[Deploy your own DAO](https://w3hc.github.io/gov-docs/deployment.html){: .btn .btn-purple }
 
 ## Features
 


### PR DESCRIPTION
## What
Update the links for the deploy your own DAO button to link to deployer rather than UI
## Why
To fix issue https://github.com/w3hc/gov-docs/issues/12